### PR TITLE
emit type definitions

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,8 +4,10 @@
     "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "../lib/",
-    "target": "es5",
-    "module": "commonjs"
+    "target": "ES2015",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "declaration": true
   },
   "files": ["browser.ts"]
 }


### PR DESCRIPTION
I wanted to use styx from typescript, so I needed type definitions emitted.

Here's a PR that changes tsconfig.js to include ES2015 as target and emit .d.ts files.